### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostTypeofConfig.cmake
+++ b/BoostTypeofConfig.cmake
@@ -1,0 +1,11 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostConfig 1.66)
+find_dependency(BoostMpl 1.66)
+find_dependency(BoostPreprocessor 1.66)
+find_dependency(BoostTypeTraits 1.66)
+find_dependency(BoostUtility 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostTypeofTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostTypeof VERSION 1.66 LANGUAGES CXX)
+
+add_library(typeof INTERFACE)
+
+target_include_directories(typeof INTERFACE 
+    $<BUILD_INTERFACE:${BoostTypeof_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostTypeof_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostConfig 1.66 REQUIRED)
+find_package(BoostMpl 1.66 REQUIRED)
+find_package(BoostPreprocessor 1.66 REQUIRED)
+find_package(BoostTypeTraits 1.66 REQUIRED)
+find_package(BoostUtility 1.66 REQUIRED)
+
+target_link_libraries(typeof
+    INTERFACE
+        Boost::config
+        Boost::mpl
+        Boost::preprocessor
+        Boost::type_traits
+        Boost::utility
+    )
+
+install(EXPORT typeof-targets
+    FILE BoostTypeofTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS typeof EXPORT typeof-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostTypeofConfigVersion.cmake"
+    VERSION ${BoostTypeof_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostTypeofConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostTypeofConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::typeof ALIAS typeof)


### PR DESCRIPTION
Expresses Boost::typeof as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostTypeof 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       └── typeof
│           ├── decltype.hpp
│           ├── dmc
│           │   └── typeof_impl.hpp
│           ├── encode_decode.hpp
│           ├── encode_decode_params.hpp
│           ├── incr_registration_group.hpp
│           ├── integral_template_param.hpp
│           ├── int_encoding.hpp
│           ├── message.hpp
│           ├── modifiers.hpp
│           ├── msvc
│           │   └── typeof_impl.hpp
│           ├── native.hpp
│           ├── pointers_data_members.hpp
│           ├── register_functions.hpp
│           ├── register_functions_iterate.hpp
│           ├── register_fundamental.hpp
│           ├── register_mem_functions.hpp
│           ├── std
│           │   ├── bitset.hpp
│           │   ├── complex.hpp
│           │   ├── deque.hpp
│           │   ├── fstream.hpp
│           │   ├── functional.hpp
│           │   ├── iostream.hpp
│           │   ├── istream.hpp
│           │   ├── iterator.hpp
│           │   ├── list.hpp
│           │   ├── locale.hpp
│           │   ├── map.hpp
│           │   ├── memory.hpp
│           │   ├── ostream.hpp
│           │   ├── queue.hpp
│           │   ├── set.hpp
│           │   ├── sstream.hpp
│           │   ├── stack.hpp
│           │   ├── streambuf.hpp
│           │   ├── string.hpp
│           │   ├── utility.hpp
│           │   ├── valarray.hpp
│           │   └── vector.hpp
│           ├── template_encoding.hpp
│           ├── template_template_param.hpp
│           ├── type_encoding.hpp
│           ├── typeof.hpp
│           ├── typeof_impl.hpp
│           ├── type_template_param.hpp
│           ├── unsupported.hpp
│           ├── vector100.hpp
│           ├── vector150.hpp
│           ├── vector200.hpp
│           ├── vector50.hpp
│           └── vector.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostTypeofConfig.cmake
            ├── BoostTypeofConfigVersion.cmake
            └── BoostTypeofTargets.cmake

9 directories, 53 files
```
- tests are __not__ included in the build